### PR TITLE
Use Host DNS resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Make docker tools behave natively on OSX using `docker-seamless-osx`.
 | Use `docker` and `docker-compose` commandline tools | Manually run `eval $(docker-machine env default)` before commandline tools will function  | **Automatic** by installing `eval` command in ~/.profile  |
 | Share `SSH_AUTH_SOCK` volumes to enable private SSH access (e.g. Github repos) | Manually run an SSH agent to your `docker-machine` and symlink SSH_AUTH_SOCK in VirtualBox to match your local path  | **Automatic** by running SSH agent forwarding as an OSX LaunchAgent  |
 | Access forwarded ports from containers on `localhost` | Forced to access the port on IP address given by `docker-machine ip default`, or by manually forwarding ports over SSH | **Automatic** by monitoring `docker events` inside an OSX LaunchAgent and forwarding newly exposed ports from VirtualBox |
+| Resolve DNS properly, particularly when using a VPN | Manually stopping Docker Machine and modifying VirtualBox resolver using `VBoxManage modifyvm $DOCKER_MACHINE_NAME --natdnshostresolver1 on` | **Automatic** by modifying VirtualBox resolver during installation |
+
+**What about Docker for Mac Beta?** As of June 2016, the Docker team is still improving the beta, which currently [cannot share SSH_AUTH_SOCK yet](https://forums.docker.com/t/can-we-re-use-the-osx-ssh-agent-socket-in-a-container/8152/5) and it also [doesn't handle DNS resolution in all cases yet](https://forums.docker.com/t/docker-for-mac-host-vpn-dns-dont-cooperate/8149).
 
 ## Installation
 

--- a/docker-seamless-osx
+++ b/docker-seamless-osx
@@ -4,6 +4,7 @@ set -e
 
 DOCKER_SEAMLESS_OSX_PROFILE=~/.profile
 DOCKER_SEAMLESS_OSX_SSH_AGENT_SOCK=/tmp/docker-seamless-osx-ssh-agent.sock
+DOCKER_SEAMLESS_OSX_SETTINGS_DIR=~/Library/Application\ Support/docker-seamless-osx
 
 #############################################################################
 # Console Logging
@@ -157,6 +158,41 @@ ensure_docker_machine_is_stopped() {
   if [ $(\docker-machine status $machine) = Running ]; then
     \docker-machine stop $machine | while read line; do log "--> $line"; done
   fi
+}
+
+#############################################################################
+# Helpers for managing settings
+#############################################################################
+
+append_settings() {
+
+  filename=$1
+  value=$2
+  settings_file=$DOCKER_SEAMLESS_OSX_SETTINGS_DIR/$filename
+
+  echo "$value" >> "$settings_file"
+}
+
+read_settings() {
+
+  filename=$1
+  settings_file=$DOCKER_SEAMLESS_OSX_SETTINGS_DIR/$filename
+
+  if [ -f "$settings_file" ]; then
+    cat "$settings_file"
+  fi
+}
+
+create_settings_directory() {
+
+  log_to_console "Creating settings directory in '$DOCKER_SEAMLESS_OSX_SETTINGS_DIR'"
+  mkdir -p "$DOCKER_SEAMLESS_OSX_SETTINGS_DIR"
+}
+
+remove_settings_directory() {
+
+  log_to_console "Removing settings directory from '$DOCKER_SEAMLESS_OSX_SETTINGS_DIR'"
+  rm -rf "$DOCKER_SEAMLESS_OSX_SETTINGS_DIR"
 }
 
 #############################################################################
@@ -359,6 +395,7 @@ case $1 in
     trap 'if [[ $? -ne 0 ]]; then log_to_console "Failed to install docker-seamless-osx"; fi' EXIT
 
     set_target_docker_machine $2
+    create_settings_directory
     ensure_docker_machine_is_running $DOCKER_SEAMLESS_OSX_TARGET_MACHINE
 
     install_shell_environment
@@ -381,6 +418,8 @@ case $1 in
     uninstall_shell_environment
     uninstall_port_forwarding
     uninstall_ssh_agent_forwarding
+
+    remove_settings_directory
 
     log_to_console "Successfully uninstalled docker-seamless-osx"
     ;;

--- a/docker-seamless-osx
+++ b/docker-seamless-osx
@@ -350,6 +350,47 @@ stop_ssh_agent_forwarding() {
 }
 
 #############################################################################
+# Host DNS Resolution
+# needed for proper DNS resolution with some VPN setups
+# https://www.virtualbox.org/manual/ch09.html#nat_host_resolver_proxy
+#############################################################################
+
+install_host_dns_resolution() {
+
+  log_to_console "Installing host DNS resolution for Machine \"$DOCKER_SEAMLESS_OSX_TARGET_MACHINE\""
+
+  dump_command="VBoxManage debugvm $DOCKER_SEAMLESS_OSX_TARGET_MACHINE info cfgm"
+  host_resolver_value=$($dump_command | grep UseHostResolver | grep -o -e '([0-9])')
+
+  if [ $host_resolver_value != "(1)" ]; then
+
+    append_settings virtualbox-dns-uninstalls.txt "$DOCKER_SEAMLESS_OSX_TARGET_MACHINE --natdnshostresolver1 off"
+
+    log_to_console "Stopping Machine \"$machine\" temporarily to modify host DNS resolution settings"
+    ensure_docker_machine_is_stopped $DOCKER_SEAMLESS_OSX_TARGET_MACHINE
+    VBoxManage modifyvm $DOCKER_SEAMLESS_OSX_TARGET_MACHINE --natdnshostresolver1 on
+    ensure_docker_machine_is_running $DOCKER_SEAMLESS_OSX_TARGET_MACHINE
+  fi
+}
+
+uninstall_host_dns_resolution() {
+
+  log_to_console "Uninstalling host DNS resolution"
+
+  read_settings virtualbox-dns-uninstalls.txt | while read entry; do
+
+    fields=($entry)
+    machine=${fields[0]}
+    key=${fields[1]}
+    value=${fields[2]}
+
+    log_to_console "Stopping Machine \"$machine\" to restore original settings for DNS resolution"
+    ensure_docker_machine_is_stopped $machine
+    VBoxManage modifyvm "$machine" "$key" "$value"
+  done
+}
+
+#############################################################################
 # Commandline Handling
 #############################################################################
 
@@ -398,6 +439,11 @@ case $1 in
     create_settings_directory
     ensure_docker_machine_is_running $DOCKER_SEAMLESS_OSX_TARGET_MACHINE
 
+    # Install host DNS resolution first because it may turn off
+    # the Docker Machine temporarily to make modifications. The
+    # other installers expect the Machine to be running.
+    install_host_dns_resolution
+
     install_shell_environment
     install_port_forwarding
     install_ssh_agent_forwarding
@@ -418,6 +464,12 @@ case $1 in
     uninstall_shell_environment
     uninstall_port_forwarding
     uninstall_ssh_agent_forwarding
+
+    # Uninstall host DNS resolution last because it may turn off
+    # the Docker Machine to make modifications. Otherwise, the other
+    # parts of the installation may try to automatically restart
+    # the Machine during uninstallation.
+    uninstall_host_dns_resolution
 
     remove_settings_directory
 


### PR DESCRIPTION
With some VPN setups, the VirtualBox will not be able to resolve DNS in the same way that the host normally would, and therefore docker cannot resolve those hosts either.

This change uses a VirtualBox flag `--natdnshostresolver1 on` to enable DNS resolution that matches the host.
