### PR TITLE
Allow DOCKER_SEAMLESS_OSX_PROFILE to be overridden on install

### DIFF
--- a/docker-seamless-osx
+++ b/docker-seamless-osx
@@ -2,7 +2,7 @@
 
 set -e
 
-DOCKER_SEAMLESS_OSX_PROFILE=~/.profile
+DOCKER_SEAMLESS_OSX_PROFILE=${DOCKER_SEAMLESS_OSX_PROFILE:-~/.profile}
 DOCKER_SEAMLESS_OSX_SSH_AGENT_SOCK=/tmp/docker-seamless-osx-ssh-agent.sock
 DOCKER_SEAMLESS_OSX_SETTINGS_DIR=~/Library/Application\ Support/docker-seamless-osx
 


### PR DESCRIPTION
I use zsh and thus ~/.zprofile, so making this change so I can do `DOCKER_SEAMLESS_OSX_PROFILE=~/.zprofile docker-seamless-osx install` when installing seamless
